### PR TITLE
Fix build on ppc64le

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -269,7 +269,7 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		let result = all
 			.pipe(util.skipDirectories())
 			.pipe(util.fixWin32DirectoryPermissions())
-			.pipe(electron(_.extend({}, config, { platform, arch, ffmpegChromium: true })))
+			.pipe(electron(_.extend({}, config, { platform, arch, ffmpegChromium: false })))
 			.pipe(filter(['**', '!LICENSE', '!LICENSES.chromium.html', '!version'], { dot: true }));
 
 		if (platform === 'linux') {


### PR DESCRIPTION
VSCode's build system was attempting to download `ffmpeg-v6.1.7-linux-ppc64.zip` from the ppc64le electron repo, which caused updating to the new electron version to fail.

This patch disables ffmpeg support.
